### PR TITLE
Allow final images to be saved/move images to model object.

### DIFF
--- a/ForestLossMetalDemo.xcodeproj/project.pbxproj
+++ b/ForestLossMetalDemo.xcodeproj/project.pbxproj
@@ -33,6 +33,10 @@
 		4C156AE3286B3C0A0036A8C1 /* MetalViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C156AE1286B3C0A0036A8C1 /* MetalViewCoordinator.swift */; };
 		4C156AE6286F49740036A8C1 /* LandsatKernel.metal in Sources */ = {isa = PBXBuildFile; fileRef = 4C156AE5286F49740036A8C1 /* LandsatKernel.metal */; };
 		4C156AE7286F49740036A8C1 /* LandsatKernel.metal in Sources */ = {isa = PBXBuildFile; fileRef = 4C156AE5286F49740036A8C1 /* LandsatKernel.metal */; };
+		4CD4D736288826EB00AFB80E /* SaveImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD4D735288826EB00AFB80E /* SaveImage.swift */; };
+		4CD4D7382888278000AFB80E /* SaveImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD4D7372888278000AFB80E /* SaveImage.swift */; };
+		4CD4D73B2888319D00AFB80E /* ImageCompositionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD4D73A2888319D00AFB80E /* ImageCompositionModel.swift */; };
+		4CD4D73C2888319D00AFB80E /* ImageCompositionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD4D73A2888319D00AFB80E /* ImageCompositionModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -54,6 +58,9 @@
 		4C156AE1286B3C0A0036A8C1 /* MetalViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalViewCoordinator.swift; sourceTree = "<group>"; };
 		4C156AE4286F477A0036A8C1 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		4C156AE5286F49740036A8C1 /* LandsatKernel.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = LandsatKernel.metal; sourceTree = "<group>"; };
+		4CD4D735288826EB00AFB80E /* SaveImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveImage.swift; sourceTree = "<group>"; };
+		4CD4D7372888278000AFB80E /* SaveImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveImage.swift; sourceTree = "<group>"; };
+		4CD4D73A2888319D00AFB80E /* ImageCompositionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCompositionModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -88,6 +95,7 @@
 		4C156AA3286AFBC00036A8C1 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				4CD4D7392888317900AFB80E /* Model */,
 				4C156AC4286AFD4E0036A8C1 /* Views */,
 				4C156AC3286AFD160036A8C1 /* Shaders */,
 				4C156AC2286AFD0A0036A8C1 /* Resources */,
@@ -111,6 +119,7 @@
 			children = (
 				4C156AC5286AFD6C0036A8C1 /* LossyearView.swift */,
 				4C156AB3286AFBC10036A8C1 /* macOS.entitlements */,
+				4CD4D735288826EB00AFB80E /* SaveImage.swift */,
 			);
 			path = macOS;
 			sourceTree = "<group>";
@@ -150,8 +159,17 @@
 			isa = PBXGroup;
 			children = (
 				4C156AD5286B00E10036A8C1 /* LossyearView.swift */,
+				4CD4D7372888278000AFB80E /* SaveImage.swift */,
 			);
 			path = iOS;
+			sourceTree = "<group>";
+		};
+		4CD4D7392888317900AFB80E /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				4CD4D73A2888319D00AFB80E /* ImageCompositionModel.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -264,8 +282,10 @@
 				4C156AB4286AFBC10036A8C1 /* ForestLossMetalDemoApp.swift in Sources */,
 				4C156AC9286AFDC80036A8C1 /* LossyearFilter.swift in Sources */,
 				4C156ACF286AFE3A0036A8C1 /* LossyearKernel.metal in Sources */,
+				4CD4D7382888278000AFB80E /* SaveImage.swift in Sources */,
 				4C156AD6286B00E10036A8C1 /* LossyearView.swift in Sources */,
 				4C156ACC286AFDF30036A8C1 /* SimpleFilter.swift in Sources */,
+				4CD4D73B2888319D00AFB80E /* ImageCompositionModel.swift in Sources */,
 				4C156AE2286B3C0A0036A8C1 /* MetalViewCoordinator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -280,8 +300,10 @@
 				4C156AC7286AFD6C0036A8C1 /* LossyearView.swift in Sources */,
 				4C156AB5286AFBC10036A8C1 /* ForestLossMetalDemoApp.swift in Sources */,
 				4C156ACA286AFDC80036A8C1 /* LossyearFilter.swift in Sources */,
+				4CD4D736288826EB00AFB80E /* SaveImage.swift in Sources */,
 				4C156AD0286AFE3A0036A8C1 /* LossyearKernel.metal in Sources */,
 				4C156ACD286AFDF30036A8C1 /* SimpleFilter.swift in Sources */,
+				4CD4D73C2888319D00AFB80E /* ImageCompositionModel.swift in Sources */,
 				4C156AE3286B3C0A0036A8C1 /* MetalViewCoordinator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ForestLossMetalDemo.xcodeproj/xcuserdata/michael.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/ForestLossMetalDemo.xcodeproj/xcuserdata/michael.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>ForestLossMetalDemo (iOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>ForestLossMetalDemo (macOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>

--- a/Shared/ForestLossMetalDemoApp.swift
+++ b/Shared/ForestLossMetalDemoApp.swift
@@ -6,17 +6,31 @@
 //
 
 import SwiftUI
+import UniformTypeIdentifiers
 
 @main
 struct ForestLossMetalDemoApp: App {
     @AppStorage("showBackground") private var showBackground = true
-    
+    private let model = ImageCompositionModel()
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environmentObject(model)
         }
         .commands {
             ToolbarCommands()
+            CommandGroup(after: .newItem) {
+                Button("Save image...") {
+                   if let url = showSavePanel(),
+                      let image = model.renderOutput(),
+                      let destination = CGImageDestinationCreateWithURL(url as CFURL, UTType.png.identifier as CFString, 1, nil)
+                    {
+                       CGImageDestinationAddImage(destination, image, nil)
+                       CGImageDestinationFinalize(destination)
+                    }
+                }.keyboardShortcut("s", modifiers: [.command])
+            }
             CommandGroup(after: .toolbar) {
                 Toggle(isOn: $showBackground) {
                     Text("Show background")

--- a/Shared/Model/ImageCompositionModel.swift
+++ b/Shared/Model/ImageCompositionModel.swift
@@ -1,0 +1,78 @@
+//
+//  ImageCompositionModel.swift
+//  ForestLossMetalDemo
+//
+//  Created by Michael Dales on 20/07/2022.
+//
+
+import Foundation
+import MetalKit
+import SwiftUI
+
+class ImageCompositionModel: ObservableObject {
+
+    private let maskImage: CIImage
+    private let backgroundImage: CIImage
+    private let lossyearImage: CIImage
+
+    private let yearFilter: LossyearFilter
+    private let combineFilter: CIFilter
+    private let maskFilter: SimpleFilter
+    private let landsatFilter:SimpleFilter
+    private let backgroundCombineFilter: CIFilter
+
+    @AppStorage("showBackground") private var showBackground = true
+    @Published var year: Double = 2000
+
+    init() {
+        maskImage = CIImage(contentsOf: Bundle.main.url(forResource: "datamask", withExtension: "tiff")!)!
+        lossyearImage = CIImage(contentsOf: Bundle.main.url(forResource: "lossyear", withExtension: "tiff")!)!
+        backgroundImage = CIImage(contentsOf: Bundle.main.url(forResource: "last", withExtension: "tiff")!)!
+
+        maskFilter = SimpleFilter(functionName: "mask_shader")
+        maskFilter.inputImage = maskImage
+
+        landsatFilter = SimpleFilter(functionName: "landsat_shader")
+        landsatFilter.inputImage = backgroundImage
+
+        backgroundCombineFilter = CIFilter(name: "CISourceOverCompositing")!
+        backgroundCombineFilter.setValue(landsatFilter.outputImage!, forKey: kCIInputBackgroundImageKey)
+        backgroundCombineFilter.setValue(maskFilter.outputImage, forKey: kCIInputImageKey)
+
+        yearFilter = LossyearFilter()
+        yearFilter.inputImage = lossyearImage
+        yearFilter.year = 20
+
+        combineFilter = CIFilter(name: "CISourceOverCompositing")!
+        combineFilter.setValue(backgroundCombineFilter.outputImage!, forKey: kCIInputBackgroundImageKey)
+    }
+
+    var getOutputImage: CIImage? {
+        // In theory I could combine this, so we update the value
+        // on filter as it updates, but it's also only needed at this point
+        yearFilter.year = year
+
+        if showBackground {
+            // Note that unless I do the setValue here, combineFilter doesn't refresh
+            // unlike yearfilter. I assume there's some caching or CIFilter assumes
+            // inputs aren't dynamic - there is probably a better way to prod it than this
+            // I'd imagine
+            combineFilter.setValue(yearFilter.outputImage!, forKey: kCIInputImageKey)
+            return combineFilter.outputImage
+        } else {
+            return yearFilter.outputImage
+        }
+    }
+
+    func renderOutput() -> CGImage? {
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            return nil
+        }
+        guard let image = getOutputImage else {
+            return nil
+        }
+
+        let context = CIContext.init(mtlDevice: device)
+        return context.createCGImage(image, from: CGRect(x: 0, y: 0, width: image.extent.size.width, height: image.extent.size.height))
+    }
+}

--- a/Shared/Shaders/LandsatKernel.metal
+++ b/Shared/Shaders/LandsatKernel.metal
@@ -20,7 +20,7 @@ extern "C" { namespace coreimage {
         // Alpha: Short Wave Infrared band 2
         //
         // For details of the bands see the landsat page:
-        //     https://landsat.gsfc.nasa.gov/satellites/landsat-8/landsat-8-bands/ 
+        //    q https://landsat.gsfc.nasa.gov/satellites/landsat-8/landsat-8-bands/ 
         //
         // This shader creates a false colour image that attempts to emphises vegitation density whilst
         // retaining land features from the red channel.

--- a/Shared/Views/ContentView.swift
+++ b/Shared/Views/ContentView.swift
@@ -8,24 +8,25 @@
 import SwiftUI
 
 struct ContentView: View {
-    @State private var year = 0.0
+//    @State private var year = 0.0
+    @EnvironmentObject private var model: ImageCompositionModel
 
     var body: some View {
         VStack {
             GeometryReader {frame in
                 HStack {
                     Spacer()
-                    LossyearView(year: $year)
+                    LossyearView()
                         .frame(width: min(frame.size.width, frame.size.height), height: min(frame.size.width, frame.size.height), alignment: .center)
                     Spacer()
                 }
             }
             Spacer()
             HStack {
-                Slider(value: $year, in: 0.0...21.0, step: 1) {
+                Slider(value: $model.year, in: 0.0...21.0, step: 1) {
                     Text("Year")
                 }
-                Text(String(format: "%d", Int(year + 2000)))
+                Text(String(format: "%d", Int(model.year + 2000)))
             }.padding()
         }
     }

--- a/iOS/LossyearView.swift
+++ b/iOS/LossyearView.swift
@@ -9,11 +9,10 @@ import SwiftUI
 import MetalKit
 
 struct LossyearView: UIViewRepresentable {
-    @Binding var year: Double
-    @AppStorage("showBackground") private var showBackground = true
+    @EnvironmentObject private var model: ImageCompositionModel
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(self)
+        Coordinator(self, model: model)
     }
 
     func makeUIView(context: Context) -> MTKView {
@@ -32,8 +31,6 @@ struct LossyearView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: MTKView, context: UIViewRepresentableContext<LossyearView>) {
-        context.coordinator.yearFilter.year = year
-        context.coordinator.showBackground = showBackground
         uiView.setNeedsDisplay(uiView.frame)
     }
 }

--- a/iOS/SaveImage.swift
+++ b/iOS/SaveImage.swift
@@ -1,0 +1,12 @@
+//
+//  SaveImage.swift
+//  ForestLossMetalDemo (iOS)
+//
+//  Created by Michael Dales on 20/07/2022.
+//
+
+import Foundation
+
+func showSavePanel() ->URL? {
+    return nil
+}

--- a/macOS/LossyearView.swift
+++ b/macOS/LossyearView.swift
@@ -9,12 +9,10 @@ import SwiftUI
 import MetalKit
 
 struct LossyearView: NSViewRepresentable {
-
-    @Binding var year: Double
-    @AppStorage("showBackground") private var showBackground = true
+    @EnvironmentObject private var model: ImageCompositionModel
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(self)
+        Coordinator(self, model: model)
     }
 
     func makeNSView(context: NSViewRepresentableContext<LossyearView>) -> MTKView {
@@ -33,9 +31,6 @@ struct LossyearView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: MTKView, context: NSViewRepresentableContext<LossyearView>) {
-        context.coordinator.yearFilter.year = year
-        context.coordinator.showBackground = showBackground
         nsView.setNeedsDisplay(nsView.frame)
     }
-
 }

--- a/macOS/SaveImage.swift
+++ b/macOS/SaveImage.swift
@@ -1,0 +1,21 @@
+//
+//  SaveImage.swift
+//  ForestLossMetalDemo (macOS)
+//
+//  Created by Michael Dales on 20/07/2022.
+//
+
+import AppKit
+
+func showSavePanel() -> URL? {
+    let savePanel = NSSavePanel()
+    savePanel.allowedContentTypes = [.png]
+    savePanel.canCreateDirectories = true
+    savePanel.isExtensionHidden = false
+    savePanel.title = "Save your image"
+    savePanel.message = "Choose a folder and a name to store the image."
+    savePanel.nameFieldLabel = "Image file name:"
+
+    let response = savePanel.runModal()
+    return response == .OK ? savePanel.url : nil
+}

--- a/macOS/macOS.entitlements
+++ b/macOS/macOS.entitlements
@@ -2,9 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.app-sandbox</key>
-    <true/>
-    <key>com.apple.security.files.user-selected.read-only</key>
-    <true/>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
1: Move the image model into a model object outside of SwiftUI
2: Provide a way on Mac to save the resulting image using a conventional file>save workflow.